### PR TITLE
Split-Path の結果が空文字列であれば、カレントディレクトリ ('.') を使うように修正

### DIFF
--- a/GenerateProjectContext.ps1
+++ b/GenerateProjectContext.ps1
@@ -84,6 +84,9 @@ catch {
 
 # -- 2. 出力先ディレクトリの確認 --
 $outputDir = Split-Path -Path $OutputFile -Parent
+if ([string]::IsNullOrEmpty($outputDir)) {
+    $outputDir = '.'
+}
 if (-not (Test-Path -Path $outputDir -PathType Container)) {
     Write-Verbose "出力ディレクトリ '$outputDir' が存在しないため作成します。"
     try {


### PR DESCRIPTION
fixed #4
